### PR TITLE
ft(adminpage): Admin can disable an account [#187364817]

### DIFF
--- a/src/components/rootcomponents/Sidebar.tsx
+++ b/src/components/rootcomponents/Sidebar.tsx
@@ -4,21 +4,25 @@ import { IoLogOutOutline } from 'react-icons/io5';
 import { CiSettings } from 'react-icons/ci';
 import { NavLink } from 'react-router-dom';
 import { FiMenu } from 'react-icons/fi';
-import { sidebarLinks } from '../../data/index';
+import { SidebarLink } from '../../data/index';
 
-export const Sidebar = () => {
+interface SidebarProps {
+  userLinks: SidebarLink[];
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ userLinks }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div>
       {/* Sidebar for large screens */}
-      <div className="hidden md:flex flex-col p-3 border-r w-64 h-screen">
+      <div className="hidden tablet:flex flex-col p-3 border-r w-64 h-screen">
         <div className="flex justify-center items-center gap-x-3 mb-12">
           <FaShoppingCart className="text-2xl" />
           <h1 className="text-2xl font-bold">Exclusive</h1>
         </div>
         <ul className="flex flex-col text-slate-600 font-semibold space-y-2">
-          {sidebarLinks.map((item) => (
+          {userLinks.map((item) => (
             <li
               key={item.id}
               className="w-full hover:bg-gray-100 cursor-pointer"
@@ -47,7 +51,7 @@ export const Sidebar = () => {
       </div>
 
       {/* Navbar for small screens */}
-      <div className="md:hidden flex flex-col p-3 border-b w-full">
+      <div className="tablet:hidden flex flex-col p-3 border-b w-full">
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-x-3">
             <FaShoppingCart className="text-2xl" />
@@ -60,7 +64,7 @@ export const Sidebar = () => {
         </div>
         {isOpen && (
           <ul className="flex flex-col text-slate-600 font-semibold space-y-2 mt-4">
-            {sidebarLinks.map((item) => (
+            {userLinks.map((item) => (
               <li
                 key={item.id}
                 className="w-full hover:bg-gray-100 cursor-pointer"

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,3 @@
-export * from './sidebarLinks';
 export * from './FeatureData';
 export * from './FooterData';
 export * from './HeroProducts';
@@ -6,5 +5,5 @@ export * from './MarqueeData';
 export * from './ReviewData';
 export * from './ServiceData';
 export * from './ShopData';
-export * from './sidebarLinks';
 export * from './VendorSidebarLinks';
+export * from './sidebarLinks';

--- a/src/data/sidebarLinks.ts
+++ b/src/data/sidebarLinks.ts
@@ -4,14 +4,14 @@ import { IoBagHandleOutline } from 'react-icons/io5';
 import { MdStarOutline, MdOutlineNotificationsActive } from 'react-icons/md';
 import React from 'react';
 
-type SidebarLink = {
+export type UserSidebarLink = {
   id: number;
   name: string;
   icon: React.ComponentType<{ className?: string }>;
   link: string;
 };
 
-export const sidebarLinks: SidebarLink[] = [
+export const sidebarLinks: UserSidebarLink[] = [
   {
     id: 1,
     name: 'Dashboard',

--- a/src/layouts/UserLayout.tsx
+++ b/src/layouts/UserLayout.tsx
@@ -1,10 +1,12 @@
 import { Outlet } from 'react-router-dom';
 import * as rootcomponents from '../components/index';
+import { sidebarLinks } from '../../src/data/index';
+
 export const UserLayout: React.FC = () => {
   return (
-    <main className="h-screen flex flex-col md:flex-row font-[outfit] overflow-hidden">
+    <main className="h-screen flex flex-col tablet:flex-row font-[outfit] overflow-hidden">
       <aside>
-        <rootcomponents.Sidebar />
+        <rootcomponents.Sidebar userLinks={sidebarLinks} />
       </aside>
       <section className="flex-1 flex flex-col bg-zinc-50">
         <main className="flex-1 overflow-y-auto pb-3">

--- a/src/pages/adminpages/Users.tsx
+++ b/src/pages/adminpages/Users.tsx
@@ -14,13 +14,14 @@ import { IUser } from '../../types';
 import { ErrorPage } from '../../utils/ErrorPage';
 import { Loading } from '../../utils/Loading';
 import { useNavigate } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 const Users: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [currentPage, setCurrentPage] = useState<number>(1);
   const usersPerPage: number = 8;
   const { data, isLoading, error, mutate } = useFetch('/api/v1/users');
   const isAuthenticated = useSelector(
-    (state: RootState) => state.user.isAuthenticated,
+    (state: RootState) => state.user?.user?.role === "ADMIN",
   );
   const navigate = useNavigate();
   const refreshUsers = () => {
@@ -30,9 +31,8 @@ const Users: React.FC = () => {
     refreshUsers();
   }, [data]);
   useEffect(() => {
-    console.log(isAuthenticated);
     if (!isAuthenticated) {
-      navigate('/auth/login');
+      navigate('/');
     }
   }, []);
 
@@ -65,6 +65,7 @@ const Users: React.FC = () => {
         <SearchBar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
       </div>
       <main>
+      <ToastContainer />
         <table className="min-w-full border bg-white">
           <TableHeader />
           <TableBody

--- a/src/pages/userpage/userSettings.tsx
+++ b/src/pages/userpage/userSettings.tsx
@@ -21,13 +21,13 @@ export const UserSettings: React.FC = () => {
   }, []);
 
   return (
-    <div className="h-screen flex flex-col md:flex-row">
+    <div className="h-screen flex flex-col tablet:flex-row">
       <div className="w-full md:w-3/5 bg-zinc-50 border-r border-gray-300">
         <div className="p-4">
           <authcomponents.EditProfile />
         </div>
       </div>
-      <div className="w-full md:w-2/5 bg-zinc-50">
+      <div className="w-full tablet:w-2/5 bg-zinc-50">
         <div className="p-4">
           <authcomponents.UpdatePassword />
         </div>

--- a/src/service/authApi.ts
+++ b/src/service/authApi.ts
@@ -85,6 +85,19 @@ const authApi = ecommerceSergeApi.injectEndpoints({
         body: { role },
       }),
     }),
+    disableAccount: builder.mutation<
+      { message: string },
+      { id: string; token: string; }
+    >({
+      query: ({ id, token }) => ({
+        url: `api/v1/admin/disable/${id}`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: ` ${token}`,
+        },
+      }),
+    }),
   }),
 });
 export const {
@@ -96,4 +109,5 @@ export const {
   useSendVerificationMutation,
   useUpdatePasswordMutation,
   useAssignRoleMutation,
+  useDisableAccountMutation,
 } = authApi;

--- a/tests/roottests/Components/button.test.tsx
+++ b/tests/roottests/Components/button.test.tsx
@@ -1,0 +1,34 @@
+// Button.test.tsx
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Button from '../../../src/components/Button';
+
+describe('Button Component', () => {
+  it('renders with correct type and title', () => {
+    render(<Button type="button" title="Test Button">Click Me</Button>);
+    
+    const button = screen.getByRole('button', { name: /click me/i });
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('type', 'button');
+    expect(button).toHaveAttribute('title', 'Test Button');
+  });
+
+  it('applies default styles', () => {
+    render(<Button type="submit" title="Submit Button">Submit</Button>);
+    
+    const button = screen.getByRole('button', { name: /submit/i });
+
+    expect(button).toHaveClass('bg-black rounded-[8px] w-[60%] text-white border border-[#E0E0E0] py-2 px-4 box-border text-[828282] hover:opacity-90');
+  });
+
+  it('renders with custom children', () => {
+    render(<Button type="reset" title="Reset Button">Reset</Button>);
+    
+    const button = screen.getByRole('button', { name: /reset/i });
+
+    expect(button).toHaveTextContent('Reset');
+  });
+});

--- a/tests/roottests/Components/input.test.tsx
+++ b/tests/roottests/Components/input.test.tsx
@@ -1,0 +1,44 @@
+// Input.test.tsx
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Input from '../../../src/components/Input';
+
+describe('Input Component', () => {
+  it('renders with default type and placeholder', () => {
+    render(<Input placeholder="Enter text" />);
+
+    const input = screen.getByPlaceholderText('Enter text');
+    
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('renders with specified type, name, and value', () => {
+    render(<Input type="email" name="email" value="test@example.com" />);
+
+    const input = screen.getByDisplayValue('test@example.com');
+    
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'email');
+    expect(input).toHaveAttribute('name', 'email');
+  });
+
+  it('applies custom class names and border color', () => {
+    render(<Input className="custom-class" borderColor="border-red-500" />);
+
+    const input = screen.getByRole('textbox');
+
+    expect(input).toHaveClass('custom-class border-red-500');
+  });
+
+  it('forwards ref to the input element', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Input ref={ref} />);
+    
+    const input = screen.getByRole('textbox');
+
+    expect(ref.current).toBe(input);
+  });
+});

--- a/tests/roottests/sidebar.test.tsx
+++ b/tests/roottests/sidebar.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Sidebar } from '../../src/components/rootcomponents/Sidebar';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from '../../src/redux/store';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { sidebarLinks } from '../../src/data/index';
+import * as rootcomponents from '../../src/components/index';
 
 describe('Sidebar Component', () => {
   test('renders sidebar component correctly', () => {
@@ -11,7 +12,7 @@ describe('Sidebar Component', () => {
       <div id="root">
         <Provider store={store}>
           <Router>
-            <Sidebar />
+            <rootcomponents.Sidebar userLinks={sidebarLinks} />
           </Router>
         </Provider>
       </div>,


### PR DESCRIPTION
## ℹ️ Description

As an admin: 

- Due to varying reasons like fraud, abuse, etc,... admin should be able to disable any user account.
- Admin dashboard should list all users with an option of disabling their accounts.

##### 📹 Loom video link: [Disable Account feature demonstration](https://www.loom.com/share/9dcb2b02a99c4d8680a5ceb119500051?sid=6e2b09bb-d9a5-4738-88ff-0c29905c0cbc)

## 🧪 How can this be tested?

This can be tested on the admin dashboard under the admin/users route

## 📸 Screenshots
<img width="1429" alt="Screenshot 2024-07-08 at 15 44 51" src="https://github.com/atlp-rwanda/e-commerce-serge-30-fn/assets/125473722/c6370e6b-9af7-4301-9bb0-be1be8d13f58">


## 📍 Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have created a loom video for the new feature or enhancement
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
