### PR TITLE
Ft(Notifcations):mark all notification as read 187364821

### DIFF
--- a/src/service/authApi.ts
+++ b/src/service/authApi.ts
@@ -202,6 +202,15 @@ const authApi = ecommerceSergeApi.injectEndpoints({
         };
       },
     }),
+    markAllAsRead: builder.mutation({
+      query: () => ({
+        url: 'api/v1/notifications/all/read',
+        method: 'PATCH',
+        headers: {
+          Authorization: localStorage.getItem('token') || '',
+        },
+      }),
+    }),
   }),
 });
 export const {
@@ -221,4 +230,5 @@ export const {
   useAddToCartMutation,
   useViewCartQuery,
   useUserDataByIdMutation,
+  useMarkAllAsReadMutation,
 } = authApi;

--- a/src/slices/notificationsSlice.ts
+++ b/src/slices/notificationsSlice.ts
@@ -18,14 +18,23 @@ const notificationsSlice = createSlice({
       state.notifications = action.payload;
     },
     markAsRead(state, action: PayloadAction<string>) {
-      state.notifications = state.notifications.map((notification) =>
-        notification.id === action.payload
-          ? { ...notification, isRead: true }
-          : notification,
+      const notification = state.notifications.find(
+        (n) => n.id === action.payload,
       );
+      if (notification) {
+        notification.isRead = true;
+      }
+    },
+    markAllAsRead(state) {
+      state.notifications = state.notifications.map((notification) => ({
+        ...notification,
+        isRead: true,
+      }));
     },
   },
 });
 
-export const { setNotifications, markAsRead } = notificationsSlice.actions;
+export const { setNotifications, markAsRead, markAllAsRead } =
+  notificationsSlice.actions;
+
 export default notificationsSlice.reducer;

--- a/tests/roottests/Components/DeliveryDetails.test.tsx
+++ b/tests/roottests/Components/DeliveryDetails.test.tsx
@@ -9,7 +9,6 @@ describe('Deliverydetails', () => {
     expect(
       screen.getByText('Enter your postal code for Delivery Availability'),
     ).toBeInTheDocument();
-
     expect(screen.getByText('Return Delivery')).toBeInTheDocument();
     expect(
       screen.getByText('Free 30 Days Delivery Returns.'),


### PR DESCRIPTION
## Ft mark all notification as read 

## ℹ️ Description

- this feature allow users to set all their notification as read

![image](https://github.com/user-attachments/assets/993ae33b-62dd-4834-9c9f-3db1228ff5d1)

![image](https://github.com/user-attachments/assets/bd42839b-71df-4678-ab2f-e2238e2f4d8a)



##### 📹 Loom video link: https://www.loom.com/share/5e7e50f84b304907bbcd3ee5d6a56314

## 🧪 How can this be tested?

Write a short description on how others can test the changes implemented in the PR

## 📸 Screenshots

_Please add screenshots of the changes here._

## 📍 Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have created a loom video for the new feature or enhancement
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
